### PR TITLE
fix: 支払方法比較のハイライト修正

### DIFF
--- a/apps/car-cost-simulator/components/PaymentComparison.tsx
+++ b/apps/car-cost-simulator/components/PaymentComparison.tsx
@@ -57,7 +57,7 @@ export default function PaymentComparison({ scenario }: Props) {
       monthly: 0,
       totalCost: cashTotal,
       note: "利息なし。まとまった資金が必要",
-      highlight: cashTotal <= loanTotal,
+      highlight: false,
     },
     {
       name: `通常ローン（${years}年）`,


### PR DESCRIPTION
現金一括の緑枠を削除