### PR TITLE
fix: add packageManager and remove @mankai/ui CSS references

### DIFF
--- a/apps/car-cost-simulator/app/globals.css
+++ b/apps/car-cost-simulator/app/globals.css
@@ -1,9 +1,7 @@
 @import "tailwindcss";
-@import "@mankai/ui/tokens.css";
 
 /* packages/ の TSX ファイルも Tailwind クラスのスキャン対象に含める */
 @source "../../packages/auth/src/**/*.tsx";
-@source "../../packages/ui/src/**/*.tsx";
 
 /* ボタン・リンクのホバーカーソル */
 button,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mankai-services",
   "private": true,
+  "packageManager": "npm@10.8.2",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
## Summary
- ルート `package.json` に `packageManager: npm@10.8.2` を追加（turbo v2 で必須）
- `car-cost-simulator/globals.css` から `@mankai/ui/tokens.css` import と `packages/ui` の `@source` を削除（`packages/ui` 未作成のためビルド失敗の原因）
- Dependency Graph を API 経由で有効化（Dependency Review ワークフローが動作するように）

## Test plan
- [ ] バンドルサイズチェック（全ワークスペースのビルド）が pass する
- [ ] Dependency Review が pass する

🤖 Generated with [Claude Code](https://claude.com/claude-code)